### PR TITLE
Fix ko.applyBindings issue where element id is not in the page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,10 +7,10 @@
     "jquery-ui": "1.12.x",
     "jquery-cookie": "1.4.x",
     "jquery-validate": "1.13.x",
-    "knockout": "3.x.x",
-    "knockout-sortable": "0.x.x",
+    "knockout": "3.5.x",
+    "knockout-sortable": "1.2.x",
     "eonasdan-bootstrap-datetimepicker": "3.1.x",
-    "select2": "3.x.x",
+    "select2": "3.5.x",
     "select2-bootstrap-css": "1.4.x",
     "bootstrap-fileinput": "4.1.x",
     "bootstrap-switch": "3.3.x"

--- a/occams/static/scripts/bindings/date.js
+++ b/occams/static/scripts/bindings/date.js
@@ -29,7 +29,7 @@
   ko.bindingHandlers.datetimepicker = {
     init: function(element, valueAccessor, allBindingsAccessor) {
 
-      if (supportsDateInput) {
+      if (window.supportsDateInput) {
         return;
       }
 

--- a/occams/static/scripts/bindings/validate.js
+++ b/occams/static/scripts/bindings/validate.js
@@ -36,8 +36,8 @@
     onfocusout: function(element, event){
       // validate, but wait half a moment otherwise we might interrupt
       // something else the user intended on clicking on, such as cancel
-      // http://stackoverflow.com/a/25797083/148781
-      window.setTimeout(function(){ this.element(element); }, 1);
+      var delay = 100; // just barely enough to click on something else
+      window.setTimeout(function(){$(element).valid();}, delay);
     },
     highlight: function(element, errorClass, validClass){
       $(element)

--- a/occams/templates/export/codebook.pt
+++ b/occams/templates/export/codebook.pt
@@ -114,8 +114,7 @@
     <script>
       $(function(){
         ko.applyBindings(
-          new CodebookViewModel,
-          document.getElementById('exports_codebook')
+          new CodebookViewModel
         );
       });
     </script>

--- a/occams/templates/export/status.pt
+++ b/occams/templates/export/status.pt
@@ -231,8 +231,7 @@
       ko.applyBindings(
         new StatusViewModel({
           notifications_url: "${request.route_path('studies.exports_notifications')}",
-        }),
-        document.getElementById('exports_status')
+        })
       );
     });
   </script>

--- a/occams/templates/form/list.pt
+++ b/occams/templates/form/list.pt
@@ -180,7 +180,7 @@
   <metal:content-slot fill-slot="javascript-slot">
     <script>
       $(function(){
-        ko.applyBindings(new FormListView, document.getElementById('form_list'));
+        ko.applyBindings(new FormListView);
       });
     </script>
 

--- a/occams/templates/patient/form.pt
+++ b/occams/templates/patient/form.pt
@@ -22,8 +22,7 @@
           new PatientView({
             patientData: JSON.parse($('#patient-data').text()),
             formsUrl: "${request.current_route_path(_route_name='studies.patient_forms')}"
-          }),
-          document.getElementById('views-patient-main')
+          })
         );
       });
     </script>

--- a/occams/templates/patient/forms.pt
+++ b/occams/templates/patient/forms.pt
@@ -86,8 +86,7 @@
             patientData: JSON.parse($('#patient-data').text()),
             entitiesData: JSON.parse($('#entities-data').text()),
             formsUrl: "${request.current_route_path(_route_name='studies.patient_forms')}"
-          }),
-          document.getElementById('views-patient-main')
+          })
         );
       });
     </script>

--- a/occams/templates/patient/search.pt
+++ b/occams/templates/patient/search.pt
@@ -104,8 +104,7 @@
         ko.applyBindings(
           new PatientSearchView({
             resultsData: JSON.parse($('#results-data').text())
-            }),
-          document.getElementById('views-patient-search'));
+            })
       });
     </script>
     <tal:json define="json import: json">

--- a/occams/templates/patient/view.pt
+++ b/occams/templates/patient/view.pt
@@ -268,8 +268,7 @@
             enrollmentsData: JSON.parse($('#enrollments-data').text()),
             visitsData: JSON.parse($('#visits-data').text()),
             formsUrl: "${request.current_route_path(_route_name='studies.patient_forms')}"
-          }),
-          document.getElementById('views-patient-main')
+          })
         );
       });
     </script>

--- a/occams/templates/study/list.pt
+++ b/occams/templates/study/list.pt
@@ -38,7 +38,7 @@
           <div class="panel-body" tal:condition="modified_count <= 0">
             <p class="text-muted text-center" i18n:translate="">Nothing viewed recently</p>
           </div>
-          <ul class="list-group" tal:condition="modified > 0">
+          <ul class="list-group" tal:condition="modified_count > 0">
             <tal:patients tal:define="humanize import:humanize" repeat="patient modified">
               <li class="list-group-item">
                 <a href="${request.route_path('studies.patient', patient=patient.pid)}">${patient.pid}</a>

--- a/occams/templates/study/view.pt
+++ b/occams/templates/study/view.pt
@@ -567,7 +567,7 @@
       $(function(){
         var scheduleUrl = "${request.current_route_path(_route_name='studies.study_schedule')}",
             studyData = JSON.parse($('#study-data').text());
-        ko.applyBindings(new StudyView(studyData, scheduleUrl), document.getElementById('study-main'));
+        ko.applyBindings(new StudyView(studyData, scheduleUrl));
         setupScheduleGrid();
       });
     </script>

--- a/occams/templates/version/editor.pt
+++ b/occams/templates/version/editor.pt
@@ -383,8 +383,7 @@
         ko.applyBindings(new VersionEditorView({
             versionUrl: "${request.current_route_path(_route_name='forms.version')}",
             fieldsUrl: "${request.current_route_path(_route_name='forms.fields')}"
-          }),
-          document.getElementById('version_editor')
+          })
         );
       });
     </script>

--- a/occams/templates/visit/view.pt
+++ b/occams/templates/visit/view.pt
@@ -86,8 +86,7 @@
         ko.applyBindings(new VisitView({
             visitData: JSON.parse($('#visit-data').text()),
             formsUrl: "${request.current_route_path(_route_name='studies.visit_forms')}"
-          }),
-          document.getElementById('view-visit')
+          })
         );
       });
     </script>


### PR DESCRIPTION
If an element is not passed to ` ko.applyBindings` , it applies to the current page, which is expected behavior. Originally, since the elements were not found in the page and empty DOM result would have been passed as a second parameter. Knockout seems to have changed this behavior in recent versions, so the pages have been readjusted to accommodate this by not specifying an element if the there is only one view on the page.